### PR TITLE
Allow axios to set multipart boundary

### DIFF
--- a/frontend/src/views/RepoDetailView.vue
+++ b/frontend/src/views/RepoDetailView.vue
@@ -249,7 +249,6 @@ const handleUpload = async () => {
 
   try {
     const { data } = await http.post(`/repos/${repoId.value}/files`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
       onUploadProgress: (event) => {
         if (!event.total) {
           return;


### PR DESCRIPTION
## Summary
- allow Axios to supply the multipart boundary automatically by removing the hard-coded Content-Type header in the repo detail upload view

## Testing
- curl -s -X POST http://localhost:3000/api/auth/login -H 'Content-Type: application/json' -d '{"username":"user","password":"user123"}'
- curl -s -X POST http://localhost:3000/api/repos -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"name":"test-repo","description":"Upload repo","visibility":"private"}'
- curl -s -X POST http://localhost:3000/api/repos/$REPO_ID/files -H "Authorization: Bearer $TOKEN" -F "file=@/tmp/upload.txt" -F "share=true" -D -

------
https://chatgpt.com/codex/tasks/task_e_68ce6841cc54832cbdbf28ca2d0d363b