### PR TITLE
Surface Dify sync failures in repo uploads

### DIFF
--- a/frontend/src/locales/index.ts
+++ b/frontend/src/locales/index.ts
@@ -135,6 +135,8 @@ export const messages = {
         uploadFailed: '上传失败',
         uploadUnexpected: '上传文件时发生未知错误',
         success: '文件上传成功',
+        difySyncFailed: '文件已上传，但同步至 Dify 知识库失败。',
+        difySyncFailedWithReason: '文件已上传，但同步至 Dify 知识库失败：{reason}',
       },
     },
     adminUsers: {
@@ -354,6 +356,8 @@ export const messages = {
         uploadFailed: 'Upload failed',
         uploadUnexpected: 'Unexpected error while uploading file',
         success: 'File uploaded successfully',
+        difySyncFailed: 'File uploaded, but syncing to the Dify knowledge base failed.',
+        difySyncFailedWithReason: 'File uploaded, but syncing to the Dify knowledge base failed: {reason}',
       },
     },
     adminUsers: {


### PR DESCRIPTION
## Summary
- surface Dify sync failures after repo uploads by showing a warning toast when the backend reports a failed sync
- extend file metadata typing to include Dify sync status and error details and add localized strings for the new warning message

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6841cc54832cbdbf28ca2d0d363b