### PR TITLE
Switch Dify search to dataset chunk retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,25 @@ The repository ships with Dockerfiles for the API and the frontend plus a Compos
 
 ```bash
 # Ensure Dify variables exist in your shell or .env file
-export DIFY_BASE_URL=https://api.dify.ai
-export DIFY_KB_ID=your_kb_id
+export DIFY_BASE_URL=https://api.dify.ai/v1
+export DIFY_DATASET_ID=your_dataset_id   # or set DIFY_KB_ID for backward compatibility
 export DIFY_API_KEY=your_api_key
 
 # Build and launch
 docker compose up --build
 ```
+
+### Dify chunk retrieval helper
+
+The backend exposes a `retrieveChunks` helper that wraps the Dify datasets retrieval API. Configure the following environment variables before invoking it directly or through the API:
+
+```bash
+export DIFY_BASE_URL=https://<your-dify-host>/v1
+export DIFY_API_KEY=sk-...
+export DIFY_DATASET_ID=...
+```
+
+If your environment requires an outbound proxy, set `HTTPS_PROXY` (and `HTTP_PROXY` when needed) before starting the server so that Node's fetch client routes requests accordingly.
 
 Services start on:
 

--- a/src/services/difyService.js
+++ b/src/services/difyService.js
@@ -11,19 +11,28 @@ function createDifyError(status, code, message) {
 
 function normalizeBaseUrl(url) {
   if (!url) return '';
-  return url.endsWith('/') ? url.slice(0, -1) : url;
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
 }
 
 function getDifyConfig() {
-  const baseUrl = normalizeBaseUrl(process.env.DIFY_BASE_URL);
-  const kbId = process.env.DIFY_KB_ID;
+  const rawBaseUrl = process.env.DIFY_BASE_URL;
+  const normalizedBaseUrl = normalizeBaseUrl(rawBaseUrl);
+  const apiBaseUrl = normalizedBaseUrl
+    ? normalizedBaseUrl.endsWith('/v1')
+      ? normalizedBaseUrl
+      : `${normalizedBaseUrl}/v1`
+    : '';
+  const kbId = process.env.DIFY_KB_ID || process.env.DIFY_DATASET_ID;
   const apiKey = process.env.DIFY_API_KEY;
 
   return {
-    baseUrl,
+    baseUrl: normalizedBaseUrl,
+    apiBaseUrl: normalizeBaseUrl(apiBaseUrl),
     kbId,
     apiKey,
-    isConfigured: Boolean(baseUrl && kbId && apiKey),
+    isConfigured: Boolean(apiBaseUrl && kbId && apiKey),
   };
 }
 
@@ -42,7 +51,7 @@ function ensureConfigured() {
 }
 
 async function uploadToDify(filePath, fileName) {
-  const { baseUrl, kbId, apiKey } = ensureConfigured();
+  const { apiBaseUrl, kbId, apiKey } = ensureConfigured();
   const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
 
   await fs.promises.access(absolutePath, fs.constants.R_OK);
@@ -50,8 +59,10 @@ async function uploadToDify(filePath, fileName) {
   const blob = new Blob([buffer]);
   const formData = new FormData();
   formData.append('file', blob, fileName);
+  formData.append('indexing_technique', 'high_quality');
+  formData.append('process_rule', JSON.stringify({ mode: 'automatic' }));
 
-  const response = await fetch(`${baseUrl}/v1/knowledge-bases/${kbId}/documents`, {
+  const response = await fetch(`${apiBaseUrl}/datasets/${kbId}/document/create-by-file`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -69,12 +80,18 @@ async function uploadToDify(filePath, fileName) {
   }
 
   const payload = await response.json();
-  if (payload?.data?.id) {
-    return payload.data.id;
-  }
+  const candidates = [
+    payload?.data?.id,
+    payload?.data?.document_id,
+    payload?.document_id,
+    payload?.documentId,
+    payload?.id,
+  ];
 
-  if (payload?.id) {
-    return payload.id;
+  for (const candidate of candidates) {
+    if (candidate) {
+      return candidate;
+    }
   }
 
   return null;
@@ -85,49 +102,37 @@ async function refreshDifyDocument(documentId) {
     return false;
   }
 
-  const { baseUrl, kbId, apiKey } = ensureConfigured();
+  const { apiBaseUrl, kbId, apiKey } = ensureConfigured();
 
-  const endpoints = [
-    `${baseUrl}/v1/knowledge-bases/${kbId}/documents/${documentId}/refresh`,
-    `${baseUrl}/v1/knowledge-bases/${kbId}/documents/${documentId}/sync`,
-    `${baseUrl}/v1/knowledge-bases/${kbId}/documents/${documentId}/index`,
-  ];
-
-  let lastError = null;
-
-  for (const url of endpoints) {
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-        },
-      });
-
-      if (response.ok) {
-        return true;
-      }
-
-      if (response.status === 404) {
-        continue;
-      }
-
-      const text = await response.text();
-      lastError = createDifyError(
-        response.status,
-        'DIFY_REFRESH_FAILED',
-        `Dify document refresh failed (${response.status}): ${text}`
-      );
-    } catch (error) {
-      lastError = error;
+  const response = await fetch(
+    `${apiBaseUrl}/datasets/${kbId}/documents/${documentId}/indexing-status`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
     }
+  );
+
+  if (response.status === 404) {
+    return false;
   }
 
-  if (lastError) {
-    throw lastError;
+  if (!response.ok) {
+    const text = await response.text();
+    throw createDifyError(
+      response.status,
+      'DIFY_REFRESH_FAILED',
+      `Dify indexing status fetch failed (${response.status}): ${text}`
+    );
   }
 
-  return false;
+  const payload = await response.json();
+  if (payload?.status) {
+    return payload.status;
+  }
+
+  return true;
 }
 
 async function deleteDifyDocument(documentId) {
@@ -135,9 +140,9 @@ async function deleteDifyDocument(documentId) {
     return false;
   }
 
-  const { baseUrl, kbId, apiKey } = ensureConfigured();
+  const { apiBaseUrl, kbId, apiKey } = ensureConfigured();
 
-  const response = await fetch(`${baseUrl}/v1/knowledge-bases/${kbId}/documents/${documentId}`, {
+  const response = await fetch(`${apiBaseUrl}/datasets/${kbId}/documents/${documentId}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -160,41 +165,139 @@ async function deleteDifyDocument(documentId) {
   return true;
 }
 
+async function retrieveChunks(options = {}) {
+  const {
+    baseUrl,
+    apiKey,
+    datasetId,
+    query,
+    retrievalModel,
+    timeoutMs = 15000,
+  } = options;
+
+  if (!baseUrl) {
+    throw createDifyError(500, 'DIFY_BASE_URL_MISSING', 'Dify baseUrl is required.');
+  }
+
+  if (!apiKey) {
+    throw createDifyError(500, 'DIFY_API_KEY_MISSING', 'Dify API key is required.');
+  }
+
+  if (!datasetId) {
+    throw createDifyError(500, 'DIFY_DATASET_ID_MISSING', 'Dify dataset id is required.');
+  }
+
+  if (!query || !query.trim()) {
+    throw createDifyError(400, 'DIFY_QUERY_REQUIRED', 'Query is required for chunk retrieval.');
+  }
+
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const url = `${normalizedBaseUrl}/datasets/${datasetId}/retrieve`;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  const body = { query: query.trim() };
+  if (retrievalModel && typeof retrievalModel === 'object' && Object.keys(retrievalModel).length > 0) {
+    body.retrieval_model = retrievalModel;
+  }
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      const timeoutError = new Error(`Dify retrieve request timed out after ${timeoutMs} ms`);
+      timeoutError.code = 'DIFY_RETRIEVE_TIMEOUT';
+      timeoutError.timeout = timeoutMs;
+      timeoutError.url = url;
+      throw timeoutError;
+    }
+
+    error.url = url;
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const rawBody = await response.text();
+    let parsedBody;
+    try {
+      parsedBody = rawBody ? JSON.parse(rawBody) : null;
+    } catch (error) {
+      parsedBody = rawBody;
+    }
+
+    const requestError = new Error(`Dify retrieve request failed with status ${response.status}`);
+    requestError.status = response.status;
+    requestError.body = parsedBody;
+    requestError.url = url;
+    throw requestError;
+  }
+
+  const payload = await response.json();
+  const records = Array.isArray(payload?.records) ? payload.records : [];
+
+  return records
+    .map(record => {
+      const segment = record?.segment || {};
+      const content = segment?.content;
+      const normalizedContent = typeof content === 'string' ? content : '';
+
+      return {
+        segmentId: segment?.id || null,
+        documentId: segment?.document_id || segment?.document?.id || null,
+        content: normalizedContent,
+        score: typeof record?.score === 'number' ? record.score : 0,
+      };
+    })
+    .filter(item => item.segmentId && item.documentId);
+}
+
 async function searchKnowledgeBase(query, options = {}) {
-  const { baseUrl, kbId, apiKey } = ensureConfigured();
+  const { apiBaseUrl, kbId, apiKey } = ensureConfigured();
 
   const page = Math.max(1, Number.parseInt(options.page, 10) || 1);
   const pageSize = Math.max(1, Math.min(50, Number.parseInt(options.pageSize, 10) || 10));
-  const offset = (page - 1) * pageSize;
 
-  const body = {
-    query,
-    top_n: pageSize,
-    offset,
-  };
+  const retrievalModel = {};
 
-  if (options.filters && Object.keys(options.filters).length > 0) {
-    body.filter = options.filters;
+  if (options.retrievalModel && typeof options.retrievalModel === 'object') {
+    Object.assign(retrievalModel, options.retrievalModel);
   }
 
-  const response = await fetch(`${baseUrl}/v1/knowledge-bases/${kbId}/search`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+  if (options.filters && typeof options.filters === 'object' && Object.keys(options.filters).length > 0) {
+    retrievalModel.metadata_filter = options.filters;
+  }
+
+  if (retrievalModel.top_k === undefined) {
+    const desired = Math.max(page * pageSize, pageSize * 2);
+    retrievalModel.top_k = Math.min(200, desired);
+  }
+
+  const records = await retrieveChunks({
+    baseUrl: apiBaseUrl,
+    apiKey,
+    datasetId: kbId,
+    query,
+    retrievalModel: Object.keys(retrievalModel).length > 0 ? retrievalModel : undefined,
+    timeoutMs: options.timeoutMs,
   });
 
-  if (!response.ok) {
-    const text = await response.text();
-    const error = new Error(`Dify search failed (${response.status}): ${text}`);
-    error.status = response.status;
-    error.code = 'DIFY_SEARCH_FAILED';
-    throw error;
-  }
-
-  return response.json();
+  return {
+    records,
+    page,
+    pageSize,
+  };
 }
 
 function isDifyConfigured() {
@@ -204,6 +307,7 @@ function isDifyConfigured() {
 module.exports = {
   uploadToDify,
   refreshDifyDocument,
+  retrieveChunks,
   searchKnowledgeBase,
   isDifyConfigured,
   deleteDifyDocument,

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -22,39 +22,6 @@ function parsePageSize(value, fallback = 10) {
   return Math.min(50, parsed);
 }
 
-function normalizeDifyItems(payload) {
-  const rawItems = payload?.data || payload?.items || [];
-  const total = typeof payload?.total === 'number' ? payload.total : rawItems.length;
-
-  const items = rawItems.map(item => {
-    const metadata = item.metadata || item.document_metadata || {};
-    const document = item.document || {};
-    const chunk = item.chunk || {};
-
-    return {
-      documentId: item.document_id || item.documentId || item.id || null,
-      fileId: metadata.fileId || metadata.file_id || null,
-      repoId: metadata.repoId || metadata.repo_id || null,
-      title:
-        item.title ||
-        document.title ||
-        metadata.title ||
-        item.document_name ||
-        chunk.document_name ||
-        'Untitled document',
-      snippet: item.content || item.snippet || chunk.text || null,
-      score:
-        typeof item.score === 'number'
-          ? item.score
-          : typeof item.similarity === 'number'
-            ? item.similarity
-            : null,
-    };
-  });
-
-  return { items, total };
-}
-
 async function performLocalSearch(user, query, options) {
   const db = await getDb();
   const normalizedQuery = query.toLowerCase();
@@ -114,22 +81,75 @@ async function performLocalSearch(user, query, options) {
   };
 }
 
-async function performDifySearch(query, options) {
-  const payload = await searchKnowledgeBase(query, {
+async function performDifySearch(user, query, options) {
+  const db = await getDb();
+
+  const { records, page, pageSize } = await searchKnowledgeBase(query, {
     page: options.page,
     pageSize: options.pageSize,
     filters: options.filters,
+    retrievalModel: options.retrievalModel,
+    timeoutMs: options.timeoutMs,
   });
 
-  const page = parsePage(options.page);
-  const pageSize = parsePageSize(options.pageSize);
+  const repoIndex = new Map(db.data.repos.map(repo => [repo.id, repo]));
+  const fileIndex = new Map(
+    db.data.files
+      .filter(file => file?.difyDocId)
+      .map(file => [file.difyDocId, file])
+  );
 
-  const normalized = normalizeDifyItems(payload);
+  const filters = options.filters || {};
+  const filteredRecords = records.filter(record => {
+    if (!record?.documentId) {
+      return false;
+    }
+
+    const file = fileIndex.get(record.documentId);
+    if (!file) {
+      return false;
+    }
+
+    if (filters.repo_id && file.repoId !== filters.repo_id) {
+      return false;
+    }
+
+    if (filters.share !== undefined && Boolean(file.share) !== filters.share) {
+      return false;
+    }
+
+    if (user.role === 'admin') {
+      return true;
+    }
+
+    const repo = repoIndex.get(file.repoId);
+    const ownsRepo = repo?.owner === user.username;
+    if (ownsRepo) {
+      return true;
+    }
+
+    return Boolean(file.share);
+  });
+
+  const startIndex = (page - 1) * pageSize;
+  const paginatedRecords = filteredRecords.slice(startIndex, startIndex + pageSize);
+
+  const items = paginatedRecords.map(record => {
+    const file = fileIndex.get(record.documentId) || {};
+    return {
+      documentId: record.documentId,
+      fileId: file.id || null,
+      repoId: file.repoId || null,
+      title: file.name || `Document ${record.documentId}`,
+      snippet: record.content,
+      score: typeof record.score === 'number' ? record.score : null,
+    };
+  });
 
   return {
     source: 'dify',
-    items: normalized.items,
-    total: typeof payload.total === 'number' ? payload.total : normalized.total,
+    items,
+    total: filteredRecords.length,
     page,
     pageSize,
   };
@@ -157,10 +177,12 @@ async function search(user, query, options = {}) {
 
   if (isDifyConfigured()) {
     try {
-      return await performDifySearch(safeQuery, {
+      return await performDifySearch(user, safeQuery, {
         page: options.page,
         pageSize: options.pageSize,
         filters: Object.keys(filters).length ? filters : undefined,
+        retrievalModel: options.retrievalModel,
+        timeoutMs: options.timeoutMs,
       });
     } catch (error) {
       const err = error;


### PR DESCRIPTION
## Summary
- add a reusable Dify `retrieveChunks` helper with timeout handling, rich errors, and normalized output
- update the search flow to map retrieved chunks to local files, enforce repo/share filters, and surface snippet content
- document the required Dify environment variables and proxy usage for the retrieval helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9d5a6e68832cb1f0642180f9d1e5